### PR TITLE
Added a fix for FieldMap issues in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,27 +4,32 @@ import "time"
 import logrus "github.com/sirupsen/logrus"
 import "flag"
 
-func init() {
+func initFlags() {
 	profile := flag.String("profile", "test", "Environment profile")
+	flag.Parse()
+
+	textFormat := logrus.TextFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.000",
+		FullTimestamp:   true,
+	}
+	jsonFormat := logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyTime:  "@timestamp",
+			logrus.FieldKeyLevel: "@level",
+			logrus.FieldKeyMsg:   "@message",
+			logrus.FieldKeyFunc:  "@caller",
+		},
+	}
 
 	if *profile == "dev" {
-		logrus.SetFormatter(&logrus.TextFormatter{
-			TimestampFormat: "2006-01-02T15:04:05.000",
-			FullTimestamp:   true,
-		})
+		logrus.SetFormatter(&textFormat)
 	} else {
-		logrus.SetFormatter(&logrus.JSONFormatter{
-			// FieldMap: FieldMap{
-			// 	FieldKeyTime:  "@timestamp",
-			// 	FieldKeyLevel: "@level",
-			// 	FieldKeyMsg:   "@message",
-			// 	FieldKeyFunc:  "@caller",
-			// },
-		})
+		logrus.SetFormatter(&jsonFormat)
 	}
 }
 
 func main() {
+	initFlags()
 	for {
 		logrus.Infof("I love logs")
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
- Changed init() to initFlags() because go liked initFlags()
- defined textFormat and jsonFormat away from logrus.SetFormatter
- - jsonFormat needs `logrus.` prepended to all of it's fields because the object is from the logrus package. Still not 100% confident on why the map keys also need this